### PR TITLE
[LLDB] Update docs on building documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,14 +29,17 @@ jobs:
     name: "Test documentation build"
     runs-on: ubuntu-latest
     steps:
-      # Fetch all the commits in a pull request so that the
+      # Fetch all the commits in a pull request + 1 so that the
       # docs-changed-subprojects step won't pull them in itself in an extremely
       # slow manner.
-      - name: Fetch LLVM sources (PR)
+      - name: Calculate number of commits to fetch (PR)
         if: ${{ github.event_name == 'pull_request' }} 
+        run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+      - name: Fetch LLVM sources (PR)
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ github.event.pull_request.commits }}
+          fetch-depth: ${{ env.PR_FETCH_DEPTH }}
       - name: Fetch LLVM sources (push)
         if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v4

--- a/lldb/docs/resources/build.rst
+++ b/lldb/docs/resources/build.rst
@@ -403,13 +403,21 @@ dependencies are required:
 * Sphinx (for the website and the Python API reference)
 * Graphviz (for the 'dot' tool)
 * doxygen (if you wish to build the C++ API reference)
+* Swig (for generating Python bindings)
 
-To install the prerequisites for building the documentation (on Debian/Ubuntu)
+To install the system prerequisites for building the documentation (on Debian/Ubuntu)
 do:
 
 ::
 
-  $ sudo apt-get install doxygen graphviz python3-sphinx
+  $ sudo apt-get install doxygen graphviz swig
+
+To install Sphinx and its dependencies, use the ``requirements.txt`` available within LLVM
+to ensure you get a working configuration:
+
+::
+
+  $ pip3 install -r /path/to/llvm-project/llvm/docs/requirements.txt
 
 To build the documentation, configure with ``LLVM_ENABLE_SPHINX=ON`` and build the desired target(s).
 

--- a/mlir/docs/Interfaces.md
+++ b/mlir/docs/Interfaces.md
@@ -409,6 +409,10 @@ comprised of the following components:
         the instance is the interface class. In the trait declaration, the
         type of the instance is the concrete entity class
         (e.g. `IntegerAttr`, `FuncOp`, etc.).
+*   Extra Trait Class Declarations (Optional: `extraTraitClassDeclaration`)
+    -   Additional C++ code that is injected into the interface trait
+        declaration.
+    -   Allows the same replacements as extra shared class declarations.
 
 `OpInterface` classes may additionally contain the following:
 

--- a/mlir/docs/Passes.md
+++ b/mlir/docs/Passes.md
@@ -60,6 +60,10 @@ This document describes the available MLIR passes and their contracts.
 
 [include "MemRefPasses.md"]
 
+## 'ml\_program' Dialect Passes
+
+[include "MLProgramPasses.md"]
+
 ## 'nvgpu' Dialect Passes
 
 [include "NVGPUPasses.md"]


### PR DESCRIPTION
This patch updates the documentation to match recent changes and make it more clear. More specifically, the process for installing sphinx has changed with the transition to myst with the requirements.txt in llvm/docs being the preferred method for installation now. In addition, the docs-lldb-html target is never generated if swig isn't installed, so having something expliti in the documentation section (even if it is mentioned as a dependency of lldb itself above) probably doesn't hurt.