### PR TITLE
[NFC][MI] Tidy Up RegState enum use (1/2) (#176091)

### DIFF
--- a/llvm/docs/MIRLangRef.rst
+++ b/llvm/docs/MIRLangRef.rst
@@ -550,33 +550,25 @@ corresponding internal ``llvm::RegState`` representation:
      - Internal Value
      - Meaning
 
-   * - ``implicit``
-     - ``RegState::Implicit``
-     - Not emitted register (e.g., carry, or temporary result).
-
-   * - ``implicit-def``
-     - ``RegState::ImplicitDefine``
-     - ``implicit`` and ``def``
-
    * - ``def``
      - ``RegState::Define``
      - Register definition.
 
-   * - ``dead``
-     - ``RegState::Dead``
-     - Unused definition.
+   * - ``implicit``
+     - ``RegState::Implicit``
+     - Not emitted register (e.g., carry, or temporary result).
 
    * - ``killed``
      - ``RegState::Kill``
      - The last use of a register.
 
+   * - ``dead``
+     - ``RegState::Dead``
+     - Unused definition.
+
    * - ``undef``
      - ``RegState::Undef``
      - Value of the register doesn't matter.
-
-   * - ``internal``
-     - ``RegState::InternalRead``
-     - Register reads a value that is defined inside the same instruction or bundle.
 
    * - ``early-clobber``
      - ``RegState::EarlyClobber``
@@ -586,9 +578,17 @@ corresponding internal ``llvm::RegState`` representation:
      - ``RegState::Debug``
      - Register 'use' is for debugging purpose.
 
+   * - ``internal``
+     - ``RegState::InternalRead``
+     - Register reads a value that is defined inside the same instruction or bundle.
+
    * - ``renamable``
      - ``RegState::Renamable``
      - Register that may be renamed.
+
+   * - ``implicit-def``
+     - ``RegState::ImplicitDefine``
+     - ``implicit`` and ``def``
 
 .. _subregister-indices:
 

--- a/llvm/include/llvm/CodeGen/MachineInstrBuilder.h
+++ b/llvm/include/llvm/CodeGen/MachineInstrBuilder.h
@@ -43,6 +43,11 @@ namespace RegState {
 
 // Keep this in sync with the table in MIRLangRef.rst.
 enum {
+  /// No Specific Flags
+  NoFlags = 0x0,
+  // Reserved value, to detect if someone is passing `true` rather than this
+  // enum.
+  _Reserved = 0x1,
   /// Register definition.
   Define = 0x2,
   /// Not emitted register (e.g. carry, or temporary result).
@@ -62,12 +67,59 @@ enum {
   InternalRead = 0x100,
   /// Register that may be renamed.
   Renamable = 0x200,
+  // Combinations of above flags
   DefineNoRead = Define | Undef,
   ImplicitDefine = Implicit | Define,
   ImplicitKill = Implicit | Kill
 };
 
 } // end namespace RegState
+
+constexpr unsigned getDefRegState(bool B) {
+  return B ? RegState::Define : RegState::NoFlags;
+}
+constexpr unsigned getImplRegState(bool B) {
+  return B ? RegState::Implicit : RegState::NoFlags;
+}
+constexpr unsigned getKillRegState(bool B) {
+  return B ? RegState::Kill : RegState::NoFlags;
+}
+constexpr unsigned getDeadRegState(bool B) {
+  return B ? RegState::Dead : RegState::NoFlags;
+}
+constexpr unsigned getUndefRegState(bool B) {
+  return B ? RegState::Undef : RegState::NoFlags;
+}
+constexpr unsigned getEarlyClobberRegState(bool B) {
+  return B ? RegState::EarlyClobber : RegState::NoFlags;
+}
+constexpr unsigned getDebugRegState(bool B) {
+  return B ? RegState::Debug : RegState::NoFlags;
+}
+constexpr unsigned getInternalReadRegState(bool B) {
+  return B ? RegState::InternalRead : RegState::NoFlags;
+}
+constexpr unsigned getRenamableRegState(bool B) {
+  return B ? RegState::Renamable : RegState::NoFlags;
+}
+
+constexpr bool hasRegState(unsigned Value, unsigned Test) {
+  return (Value & Test) == Test;
+}
+
+/// Get all register state flags from machine operand \p RegOp.
+constexpr unsigned getRegState(const MachineOperand &RegOp) {
+  assert(RegOp.isReg() && "Not a register operand");
+  return getDefRegState(RegOp.isDef()) | getImplRegState(RegOp.isImplicit()) |
+         getKillRegState(RegOp.isKill()) | getDeadRegState(RegOp.isDead()) |
+         getUndefRegState(RegOp.isUndef()) |
+         // FIXME: why is this not included
+         // getEarlyClobberRegState(RegOp.isEarlyClobber()) |
+         getInternalReadRegState(RegOp.isInternalRead()) |
+         getDebugRegState(RegOp.isDebug()) |
+         getRenamableRegState(RegOp.getReg().isPhysical() &&
+                              RegOp.isRenamable());
+}
 
 /// Set of metadata that should be preserved when using BuildMI(). This provides
 /// a more convenient way of preserving certain data from the original
@@ -138,21 +190,21 @@ public:
   Register getReg(unsigned Idx) const { return MI->getOperand(Idx).getReg(); }
 
   /// Add a new virtual register operand.
-  const MachineInstrBuilder &addReg(Register RegNo, unsigned flags = 0,
+  const MachineInstrBuilder &addReg(Register RegNo, unsigned Flags = 0,
                                     unsigned SubReg = 0) const {
-    assert((flags & 0x1) == 0 &&
+    assert(!hasRegState(Flags, RegState::_Reserved) &&
            "Passing in 'true' to addReg is forbidden! Use enums instead.");
-    MI->addOperand(*MF, MachineOperand::CreateReg(RegNo,
-                                               flags & RegState::Define,
-                                               flags & RegState::Implicit,
-                                               flags & RegState::Kill,
-                                               flags & RegState::Dead,
-                                               flags & RegState::Undef,
-                                               flags & RegState::EarlyClobber,
-                                               SubReg,
-                                               flags & RegState::Debug,
-                                               flags & RegState::InternalRead,
-                                               flags & RegState::Renamable));
+    MI->addOperand(*MF, MachineOperand::CreateReg(
+                            RegNo, hasRegState(Flags, RegState::Define),
+                            hasRegState(Flags, RegState::Implicit),
+                            hasRegState(Flags, RegState::Kill),
+                            hasRegState(Flags, RegState::Dead),
+                            hasRegState(Flags, RegState::Undef),
+                            hasRegState(Flags, RegState::EarlyClobber), SubReg,
+                            hasRegState(Flags, RegState::Debug),
+                            hasRegState(Flags, RegState::InternalRead),
+                            hasRegState(Flags, RegState::Renamable)));
+
     return *this;
   }
 
@@ -166,7 +218,7 @@ public:
   /// `RegState::Define` when calling this function.
   const MachineInstrBuilder &addUse(Register RegNo, unsigned Flags = 0,
                                     unsigned SubReg = 0) const {
-    assert(!(Flags & RegState::Define) &&
+    assert(!hasRegState(Flags, RegState::Define) &&
            "Misleading addUse defines register, use addReg instead.");
     return addReg(RegNo, Flags, SubReg);
   }
@@ -555,43 +607,6 @@ LLVM_ABI MachineInstr *buildDbgValueForSpill(
 /// modifying an instruction in place while iterating over a basic block.
 LLVM_ABI void updateDbgValueForSpill(MachineInstr &Orig, int FrameIndex,
                                      Register Reg);
-
-inline unsigned getDefRegState(bool B) {
-  return B ? RegState::Define : 0;
-}
-inline unsigned getImplRegState(bool B) {
-  return B ? RegState::Implicit : 0;
-}
-inline unsigned getKillRegState(bool B) {
-  return B ? RegState::Kill : 0;
-}
-inline unsigned getDeadRegState(bool B) {
-  return B ? RegState::Dead : 0;
-}
-inline unsigned getUndefRegState(bool B) {
-  return B ? RegState::Undef : 0;
-}
-inline unsigned getInternalReadRegState(bool B) {
-  return B ? RegState::InternalRead : 0;
-}
-inline unsigned getDebugRegState(bool B) {
-  return B ? RegState::Debug : 0;
-}
-inline unsigned getRenamableRegState(bool B) {
-  return B ? RegState::Renamable : 0;
-}
-
-/// Get all register state flags from machine operand \p RegOp.
-inline unsigned getRegState(const MachineOperand &RegOp) {
-  assert(RegOp.isReg() && "Not a register operand");
-  return getDefRegState(RegOp.isDef()) | getImplRegState(RegOp.isImplicit()) |
-         getKillRegState(RegOp.isKill()) | getDeadRegState(RegOp.isDead()) |
-         getUndefRegState(RegOp.isUndef()) |
-         getInternalReadRegState(RegOp.isInternalRead()) |
-         getDebugRegState(RegOp.isDebug()) |
-         getRenamableRegState(RegOp.getReg().isPhysical() &&
-                              RegOp.isRenamable());
-}
 
 /// Helper class for constructing bundles of MachineInstrs.
 ///

--- a/llvm/lib/CodeGen/GlobalISel/InlineAsmLowering.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/InlineAsmLowering.cpp
@@ -368,9 +368,9 @@ bool InlineAsmLowering::lowerInlineAsm(
         Inst.addImm(Flag);
 
         for (Register Reg : OpInfo.Regs) {
-          Inst.addReg(Reg,
-                      RegState::Define | getImplRegState(Reg.isPhysical()) |
-                          (OpInfo.isEarlyClobber ? RegState::EarlyClobber : 0));
+          Inst.addReg(Reg, RegState::Define |
+                               getImplRegState(Reg.isPhysical()) |
+                               getEarlyClobberRegState(OpInfo.isEarlyClobber));
         }
 
         // Remember this output operand for later processing

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -1768,7 +1768,7 @@ bool MIParser::assignRegisterTies(MachineInstr &MI,
 bool MIParser::parseRegisterOperand(MachineOperand &Dest,
                                     std::optional<unsigned> &TiedDefIdx,
                                     bool IsDef) {
-  unsigned Flags = IsDef ? RegState::Define : 0;
+  unsigned Flags = getDefRegState(IsDef);
   while (Token.isRegisterFlag()) {
     if (parseRegisterFlag(Flags))
       return true;
@@ -1795,7 +1795,7 @@ bool MIParser::parseRegisterOperand(MachineOperand &Dest,
         return true;
   }
   MachineRegisterInfo &MRI = MF.getRegInfo();
-  if ((Flags & RegState::Define) == 0) {
+  if (!hasRegState(Flags, RegState::Define)) {
     if (consumeIfPresent(MIToken::lparen)) {
       unsigned Idx;
       if (!parseRegisterTiedDefIndex(Idx))
@@ -1843,19 +1843,23 @@ bool MIParser::parseRegisterOperand(MachineOperand &Dest,
       return error("generic virtual registers must have a type");
   }
 
-  if (Flags & RegState::Define) {
-    if (Flags & RegState::Kill)
+  if (hasRegState(Flags, RegState::Define)) {
+    if (hasRegState(Flags, RegState::Kill))
       return error("cannot have a killed def operand");
   } else {
-    if (Flags & RegState::Dead)
+    if (hasRegState(Flags, RegState::Dead))
       return error("cannot have a dead use operand");
   }
 
-  Dest = MachineOperand::CreateReg(
-      Reg, Flags & RegState::Define, Flags & RegState::Implicit,
-      Flags & RegState::Kill, Flags & RegState::Dead, Flags & RegState::Undef,
-      Flags & RegState::EarlyClobber, SubReg, Flags & RegState::Debug,
-      Flags & RegState::InternalRead, Flags & RegState::Renamable);
+  Dest = MachineOperand::CreateReg(Reg, hasRegState(Flags, RegState::Define),
+                                   hasRegState(Flags, RegState::Implicit),
+                                   hasRegState(Flags, RegState::Kill),
+                                   hasRegState(Flags, RegState::Dead),
+                                   hasRegState(Flags, RegState::Undef),
+                                   hasRegState(Flags, RegState::EarlyClobber),
+                                   SubReg, hasRegState(Flags, RegState::Debug),
+                                   hasRegState(Flags, RegState::InternalRead),
+                                   hasRegState(Flags, RegState::Renamable));
 
   return false;
 }

--- a/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
@@ -137,8 +137,8 @@ bool AArch64ExpandPseudo::expandMOVImm(MachineBasicBlock &MBB,
                                        unsigned BitSize) {
   MachineInstr &MI = *MBBI;
   Register DstReg = MI.getOperand(0).getReg();
-  uint64_t RenamableState =
-      MI.getOperand(0).isRenamable() ? RegState::Renamable : 0;
+  unsigned RenamableState =
+      getRenamableRegState(MI.getOperand(0).isRenamable());
   uint64_t Imm = MI.getOperand(1).getImm();
 
   if (DstReg == AArch64::XZR || DstReg == AArch64::WZR) {
@@ -617,7 +617,7 @@ bool AArch64ExpandPseudo::expand_DestructiveOp(
   }
 
   // Preserve undef state until DOP's reg is defined.
-  unsigned DOPRegState = MI.getOperand(DOPIdx).isUndef() ? RegState::Undef : 0;
+  unsigned DOPRegState = getUndefRegState(MI.getOperand(DOPIdx).isUndef());
 
   //
   // Create the destructive operation (if required)
@@ -792,9 +792,8 @@ bool AArch64ExpandPseudo::expandSVESpillFill(MachineBasicBlock &MBB,
   assert((Opc == AArch64::LDR_ZXI || Opc == AArch64::STR_ZXI ||
           Opc == AArch64::LDR_PXI || Opc == AArch64::STR_PXI) &&
          "Unexpected opcode");
-  unsigned RState = (Opc == AArch64::LDR_ZXI || Opc == AArch64::LDR_PXI)
-                        ? RegState::Define
-                        : 0;
+  unsigned RState =
+      getDefRegState(Opc == AArch64::LDR_ZXI || Opc == AArch64::LDR_PXI);
   unsigned sub0 = (Opc == AArch64::LDR_ZXI || Opc == AArch64::STR_ZXI)
                       ? AArch64::zsub0
                       : AArch64::psub0;

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -3135,7 +3135,7 @@ MachineBasicBlock *AArch64TargetLowering::EmitZTInstr(MachineInstr &MI,
   MachineInstrBuilder MIB;
 
   MIB = BuildMI(*BB, MI, MI.getDebugLoc(), TII->get(Opcode))
-            .addReg(MI.getOperand(0).getReg(), Op0IsDef ? RegState::Define : 0);
+            .addReg(MI.getOperand(0).getReg(), getDefRegState(Op0IsDef));
   for (unsigned I = 1; I < MI.getNumOperands(); ++I)
     MIB.add(MI.getOperand(I));
 

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -4064,7 +4064,7 @@ MachineInstr *AArch64InstrInfo::emitLdStWithAddr(MachineInstr &MemI,
       MRI.constrainRegClass(AM.BaseReg, &AArch64::GPR64spRegClass);
       auto B = BuildMI(MBB, MemI, DL, get(Opcode))
                    .addReg(MemI.getOperand(0).getReg(),
-                           MemI.mayLoad() ? RegState::Define : 0)
+                           getDefRegState(MemI.mayLoad()))
                    .addReg(AM.BaseReg)
                    .addReg(AM.ScaledReg)
                    .addImm(0)
@@ -4085,13 +4085,13 @@ MachineInstr *AArch64InstrInfo::emitLdStWithAddr(MachineInstr &MemI,
     else
       Opcode = scaledOffsetOpcode(Opcode, Scale);
 
-    auto B = BuildMI(MBB, MemI, DL, get(Opcode))
-                 .addReg(MemI.getOperand(0).getReg(),
-                         MemI.mayLoad() ? RegState::Define : 0)
-                 .addReg(AM.BaseReg)
-                 .addImm(AM.Displacement / Scale)
-                 .setMemRefs(MemI.memoperands())
-                 .setMIFlags(MemI.getFlags());
+    auto B =
+        BuildMI(MBB, MemI, DL, get(Opcode))
+            .addReg(MemI.getOperand(0).getReg(), getDefRegState(MemI.mayLoad()))
+            .addReg(AM.BaseReg)
+            .addImm(AM.Displacement / Scale)
+            .setMemRefs(MemI.memoperands())
+            .setMIFlags(MemI.getFlags());
     return B.getInstr();
   }
 
@@ -4110,15 +4110,15 @@ MachineInstr *AArch64InstrInfo::emitLdStWithAddr(MachineInstr &MemI,
       BuildMI(MBB, MemI, DL, get(TargetOpcode::COPY), OffsetReg)
           .addReg(AM.ScaledReg, 0, AArch64::sub_32);
     }
-    auto B = BuildMI(MBB, MemI, DL, get(Opcode))
-                 .addReg(MemI.getOperand(0).getReg(),
-                         MemI.mayLoad() ? RegState::Define : 0)
-                 .addReg(AM.BaseReg)
-                 .addReg(OffsetReg)
-                 .addImm(AM.Form == ExtAddrMode::Formula::SExtScaledReg)
-                 .addImm(AM.Scale != 1)
-                 .setMemRefs(MemI.memoperands())
-                 .setMIFlags(MemI.getFlags());
+    auto B =
+        BuildMI(MBB, MemI, DL, get(Opcode))
+            .addReg(MemI.getOperand(0).getReg(), getDefRegState(MemI.mayLoad()))
+            .addReg(AM.BaseReg)
+            .addReg(OffsetReg)
+            .addImm(AM.Form == ExtAddrMode::Formula::SExtScaledReg)
+            .addImm(AM.Scale != 1)
+            .setMemRefs(MemI.memoperands())
+            .setMIFlags(MemI.getFlags());
 
     return B.getInstr();
   }

--- a/llvm/lib/Target/AMDGPU/GCNDPPCombine.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNDPPCombine.cpp
@@ -256,7 +256,7 @@ MachineInstr *GCNDPPCombine::createDPPInst(MachineInstr &OrigMI,
               TII->getNamedOperand(MovMI, AMDGPU::OpName::vdst)->getReg()),
           *MRI));
       auto *Def = getVRegSubRegDef(CombOldVGPR, *MRI);
-      DPPInst.addReg(CombOldVGPR.Reg, Def ? 0 : RegState::Undef,
+      DPPInst.addReg(CombOldVGPR.Reg, getUndefRegState(!Def),
                      CombOldVGPR.SubReg);
       ++NumOperands;
     } else if (TII->isVOPC(DPPOp) || (TII->isVOP3(DPPOp) && OrigOpE32 != -1 &&

--- a/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
@@ -1336,8 +1336,8 @@ bool GCNHazardRecognizer::fixVcmpxPermlaneHazards(MachineInstr *MI) {
   bool IsUndef = Src0->isUndef();
   BuildMI(*MI->getParent(), MI, MI->getDebugLoc(),
           TII->get(AMDGPU::V_MOV_B32_e32))
-    .addReg(Reg, RegState::Define | (IsUndef ? RegState::Dead : 0))
-    .addReg(Reg, IsUndef ? RegState::Undef : RegState::Kill);
+      .addReg(Reg, RegState::Define | getDeadRegState(IsUndef))
+      .addReg(Reg, IsUndef ? RegState::Undef : RegState::Kill);
 
   return true;
 }

--- a/llvm/lib/Target/AMDGPU/R600MachineCFGStructurizer.cpp
+++ b/llvm/lib/Target/AMDGPU/R600MachineCFGStructurizer.cpp
@@ -464,7 +464,7 @@ void R600MachineCFGStructurizer::insertCondBranchBefore(
   MachineInstr *NewMI = MF->CreateMachineInstr(TII->get(NewOpcode), DL);
   MBB->insert(I, NewMI);
   MachineInstrBuilder MIB(*MF, NewMI);
-  MIB.addReg(OldMI->getOperand(1).getReg(), false);
+  MIB.addReg(OldMI->getOperand(1).getReg());
   SHOWNEWINSTR(NewMI);
   //erase later oldInstr->eraseFromParent();
 }
@@ -476,7 +476,7 @@ void R600MachineCFGStructurizer::insertCondBranchBefore(
   MachineInstr *NewInstr = MF->CreateMachineInstr(TII->get(NewOpcode), DL);
   //insert before
   blk->insert(I, NewInstr);
-  MachineInstrBuilder(*MF, NewInstr).addReg(RegNum, false);
+  MachineInstrBuilder(*MF, NewInstr).addReg(RegNum);
   SHOWNEWINSTR(NewInstr);
 }
 

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -2305,11 +2305,11 @@ bool SIInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
     assert(VecReg == MI.getOperand(1).getReg());
 
     MachineInstrBuilder MIB =
-      BuildMI(MBB, MI, DL, OpDesc)
-        .addReg(RI.getSubReg(VecReg, SubReg), RegState::Undef)
-        .add(MI.getOperand(2))
-        .addReg(VecReg, RegState::ImplicitDefine)
-        .addReg(VecReg, RegState::Implicit | (IsUndef ? RegState::Undef : 0));
+        BuildMI(MBB, MI, DL, OpDesc)
+            .addReg(RI.getSubReg(VecReg, SubReg), RegState::Undef)
+            .add(MI.getOperand(2))
+            .addReg(VecReg, RegState::ImplicitDefine)
+            .addReg(VecReg, RegState::Implicit | getUndefRegState(IsUndef));
 
     const int ImpDefIdx =
         OpDesc.getNumOperands() + OpDesc.implicit_uses().size();
@@ -2349,8 +2349,7 @@ bool SIInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
             .addReg(RI.getSubReg(VecReg, SubReg), RegState::Undef)
             .add(MI.getOperand(2))
             .addReg(VecReg, RegState::ImplicitDefine)
-            .addReg(VecReg,
-                    RegState::Implicit | (IsUndef ? RegState::Undef : 0));
+            .addReg(VecReg, RegState::Implicit | getUndefRegState(IsUndef));
 
     const int ImpDefIdx =
         OpDesc.getNumOperands() + OpDesc.implicit_uses().size();
@@ -2393,7 +2392,7 @@ bool SIInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
     BuildMI(MBB, MI, DL, get(AMDGPU::V_MOV_B32_indirect_read))
         .addDef(Dst)
         .addReg(RI.getSubReg(VecReg, SubReg), RegState::Undef)
-        .addReg(VecReg, RegState::Implicit | (IsUndef ? RegState::Undef : 0));
+        .addReg(VecReg, RegState::Implicit | getUndefRegState(IsUndef));
 
     MachineInstr *SetOff = BuildMI(MBB, MI, DL, get(AMDGPU::S_SET_GPR_IDX_OFF));
 
@@ -2671,7 +2670,7 @@ SIInstrInfo::expandMovDPP64(MachineInstr &MI) const {
         if (Src.isPhysical())
           MovDPP.addReg(RI.getSubReg(Src, Sub));
         else
-          MovDPP.addReg(Src, SrcOp.isUndef() ? RegState::Undef : 0, Sub);
+          MovDPP.addReg(Src, getUndefRegState(SrcOp.isUndef()), Sub);
       }
     }
 

--- a/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
+++ b/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
@@ -1356,8 +1356,7 @@ void SIPeepholeSDWA::legalizeScalarOperands(MachineInstr &MI,
     if (Op.isImm())
       Copy.addImm(Op.getImm());
     else if (Op.isReg())
-      Copy.addReg(Op.getReg(), Op.isKill() ? RegState::Kill : 0,
-                  Op.getSubReg());
+      Copy.addReg(Op.getReg(), getKillRegState(Op.isKill()), Op.getSubReg());
     Op.ChangeToRegister(VGPR, false);
   }
 }

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -2653,7 +2653,7 @@ bool SIRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator MI,
 
           BuildMI(*MBB, *MI, DL, TII->get(AMDGPU::V_MOV_B32_e32), ScavengedVGPR)
               .addReg(MaterializedReg,
-                      MaterializedReg != FrameReg ? RegState::Kill : 0);
+                      getKillRegState(MaterializedReg != FrameReg));
           MaterializedReg = ScavengedVGPR;
         }
 
@@ -2666,7 +2666,7 @@ bool SIRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator MI,
           AddI32.add(MI->getOperand(1));
 
         unsigned MaterializedRegFlags =
-            MaterializedReg != FrameReg ? RegState::Kill : 0;
+            getKillRegState(MaterializedReg != FrameReg);
 
         if (isVGPRClass(getPhysRegBaseClass(MaterializedReg))) {
           // If we know we have a VGPR already, it's more likely the other

--- a/llvm/lib/Target/ARM/ARMExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/ARM/ARMExpandPseudoInsts.cpp
@@ -2093,7 +2093,7 @@ static void CMSEPushCalleeSaves(const TargetInstrInfo &TII,
         BuildMI(MBB, MBBI, DL, TII.get(ARM::tPUSH)).add(predOps(ARMCC::AL));
     for (unsigned Reg = ARM::R4; Reg < ARM::R8; ++Reg) {
       PushMIB.addReg(
-          Reg, Reg == JumpReg || LiveRegs.contains(Reg) ? 0 : RegState::Undef);
+          Reg, getUndefRegState(Reg != JumpReg && !LiveRegs.contains(Reg)));
     }
 
     // Thumb1 can only tPUSH low regs, so we copy the high regs to the low
@@ -2108,7 +2108,7 @@ static void CMSEPushCalleeSaves(const TargetInstrInfo &TII,
       if (JumpReg == LoReg)
         continue;
       BuildMI(MBB, MBBI, DL, TII.get(ARM::tMOVr), LoReg)
-          .addReg(HiReg, LiveRegs.contains(HiReg) ? 0 : RegState::Undef)
+          .addReg(HiReg, getUndefRegState(!LiveRegs.contains(HiReg)))
           .add(predOps(ARMCC::AL));
       --HiReg;
     }
@@ -2126,7 +2126,7 @@ static void CMSEPushCalleeSaves(const TargetInstrInfo &TII,
     if (JumpReg >= ARM::R4 && JumpReg <= ARM::R7) {
       Register LoReg = JumpReg == ARM::R4 ? ARM::R5 : ARM::R4;
       BuildMI(MBB, MBBI, DL, TII.get(ARM::tMOVr), LoReg)
-          .addReg(ARM::R8, LiveRegs.contains(ARM::R8) ? 0 : RegState::Undef)
+          .addReg(ARM::R8, getUndefRegState(!LiveRegs.contains(ARM::R8)))
           .add(predOps(ARMCC::AL));
       BuildMI(MBB, MBBI, DL, TII.get(ARM::tPUSH))
           .add(predOps(ARMCC::AL))
@@ -2139,7 +2139,7 @@ static void CMSEPushCalleeSaves(const TargetInstrInfo &TII,
             .add(predOps(ARMCC::AL));
     for (unsigned Reg = ARM::R4; Reg < ARM::R12; ++Reg) {
       PushMIB.addReg(
-          Reg, Reg == JumpReg || LiveRegs.contains(Reg) ? 0 : RegState::Undef);
+          Reg, getUndefRegState(Reg != JumpReg && !LiveRegs.contains(Reg)));
     }
   }
 }
@@ -2869,8 +2869,8 @@ bool ARMExpandPseudo::ExpandMI(MachineBasicBlock &MBB,
       // Add the source operands (D subregs).
       Register D0 = TRI->getSubReg(SrcReg, ARM::dsub_0);
       Register D1 = TRI->getSubReg(SrcReg, ARM::dsub_1);
-      MIB.addReg(D0, SrcIsKill ? RegState::Kill : 0)
-         .addReg(D1, SrcIsKill ? RegState::Kill : 0);
+      MIB.addReg(D0, getKillRegState(SrcIsKill))
+          .addReg(D1, getKillRegState(SrcIsKill));
 
       if (SrcIsKill)      // Add an implicit kill for the Q register.
         MIB->addRegisterKilled(SrcReg, TRI, true);
@@ -3272,9 +3272,9 @@ bool ARMExpandPseudo::ExpandMI(MachineBasicBlock &MBB,
           BuildMI(MBB, MBBI, MI.getDebugLoc(),
                   TII->get(Opcode == ARM::LOADDUAL ? ARM::LDRD : ARM::STRD))
               .addReg(TRI->getSubReg(PairReg, ARM::gsub_0),
-                      Opcode == ARM::LOADDUAL ? RegState::Define : 0)
+                      getDefRegState(Opcode == ARM::LOADDUAL))
               .addReg(TRI->getSubReg(PairReg, ARM::gsub_1),
-                      Opcode == ARM::LOADDUAL ? RegState::Define : 0);
+                      getDefRegState(Opcode == ARM::LOADDUAL));
       for (const MachineOperand &MO : llvm::drop_begin(MI.operands()))
         MIB.add(MO);
       MIB.add(predOps(ARMCC::AL));

--- a/llvm/lib/Target/ARM/ARMFixCortexA57AES1742098Pass.cpp
+++ b/llvm/lib/Target/ARM/ARMFixCortexA57AES1742098Pass.cpp
@@ -408,7 +408,7 @@ void ARMFixCortexA57AES1742098::insertAESFixup(
   // The def and the uses are still marked as Renamable if the original register
   // was, to avoid having to rummage through all the other uses and defs and
   // unset their renamable bits.
-  unsigned Renamable = OperandToFixup->isRenamable() ? RegState::Renamable : 0;
+  unsigned Renamable = getRenamableRegState(OperandToFixup->isRenamable());
   BuildMI(*FixupLoc.Block, FixupLoc.InsertionPt, DebugLoc(),
           TII->get(ARM::VORRq))
       .addReg(RegToFixup, RegState::Define | Renamable)

--- a/llvm/lib/Target/ARM/Thumb2SizeReduction.cpp
+++ b/llvm/lib/Target/ARM/Thumb2SizeReduction.cpp
@@ -477,7 +477,7 @@ Thumb2SizeReduce::ReduceLoadStore(MachineBasicBlock &MBB, MachineInstr *MI,
                    .addReg(Rn)
                    .addImm(PredImm)
                    .addReg(PredReg)
-                   .addReg(Rt, IsStore ? 0 : RegState::Define);
+                   .addReg(Rt, getDefRegState(!IsStore));
 
     // Transfer memoperands.
     MIB.setMemRefs(MI->memoperands());

--- a/llvm/lib/Target/Hexagon/HexagonExpandCondsets.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonExpandCondsets.cpp
@@ -639,7 +639,7 @@ MachineInstr *HexagonExpandCondsets::genCondTfrFor(MachineOperand &SrcOp,
   /// predicate.
 
   unsigned Opc = getCondTfrOpcode(SrcOp, PredSense);
-  unsigned DstState = RegState::Define | (ReadUndef ? RegState::Undef : 0);
+  unsigned DstState = RegState::Define | getUndefRegState(ReadUndef);
   unsigned PredState = getRegState(PredOp) & ~RegState::Kill;
   MachineInstrBuilder MIB;
 
@@ -889,7 +889,7 @@ void HexagonExpandCondsets::predicateAt(const MachineOperand &DefOp,
   // Add the new def, then the predicate register, then the rest of the
   // operands.
   MB.addReg(DefOp.getReg(), getRegState(DefOp), DefOp.getSubReg());
-  MB.addReg(PredOp.getReg(), PredOp.isUndef() ? RegState::Undef : 0,
+  MB.addReg(PredOp.getReg(), getUndefRegState(PredOp.isUndef()),
             PredOp.getSubReg());
   while (Ox < NP) {
     MachineOperand &MO = MI.getOperand(Ox);

--- a/llvm/lib/Target/LoongArch/LoongArchInstrInfo.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchInstrInfo.cpp
@@ -915,8 +915,7 @@ LoongArchInstrInfo::emitLdStWithAddr(MachineInstr &MemI,
   switch (MemIOp) {
   default:
     return BuildMI(MBB, MemI, DL, get(MemIOp))
-        .addReg(MemI.getOperand(0).getReg(),
-                MemI.mayLoad() ? RegState::Define : 0)
+        .addReg(MemI.getOperand(0).getReg(), getDefRegState(MemI.mayLoad()))
         .addReg(AM.BaseReg)
         .addImm(AM.Displacement)
         .setMemRefs(MemI.memoperands())

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -14587,7 +14587,7 @@ PPCTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
     BuildMI(*BB, MI, DL,
             MI.getOpcode() == PPC::LQX_PSEUDO ? TII->get(PPC::LQ)
                                               : TII->get(PPC::STQ))
-        .addReg(Val, MI.getOpcode() == PPC::LQX_PSEUDO ? RegState::Define : 0)
+        .addReg(Val, getDefRegState(MI.getOpcode() == PPC::LQX_PSEUDO))
         .addImm(0)
         .addReg(Ptr);
   } else if (MI.getOpcode() == PPC::LWAT_PSEUDO ||

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
@@ -2722,7 +2722,7 @@ bool PPCInstrInfo::optimizeCompareInstr(MachineInstr &CmpInstr, Register SrcReg,
   MachineBasicBlock::iterator MII = MI;
   BuildMI(*MI->getParent(), std::next(MII), MI->getDebugLoc(),
           get(TargetOpcode::COPY), CRReg)
-    .addReg(PPC::CR0, MIOpC != NewOpC ? RegState::Kill : 0);
+      .addReg(PPC::CR0, getKillRegState(MIOpC != NewOpC));
 
   // Even if CR0 register were dead before, it is alive now since the
   // instruction we just built uses it.

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -3340,8 +3340,7 @@ MachineInstr *RISCVInstrInfo::emitLdStWithAddr(MachineInstr &MemI,
          "Addressing mode not supported for folding");
 
   return BuildMI(MBB, MemI, DL, get(MemI.getOpcode()))
-      .addReg(MemI.getOperand(0).getReg(),
-              MemI.mayLoad() ? RegState::Define : 0)
+      .addReg(MemI.getOperand(0).getReg(), getDefRegState(MemI.mayLoad()))
       .addReg(AM.BaseReg)
       .addImm(AM.Displacement)
       .setMemRefs(MemI.memoperands())

--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.cpp
@@ -71,7 +71,7 @@ void WebAssemblyInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
   unsigned CopyOpcode = WebAssembly::getCopyOpcodeForRegClass(RC);
 
   BuildMI(MBB, I, DL, get(CopyOpcode), DestReg)
-      .addReg(SrcReg, KillSrc ? RegState::Kill : 0);
+      .addReg(SrcReg, getKillRegState(KillSrc));
 }
 
 MachineInstr *WebAssemblyInstrInfo::commuteInstructionImpl(

--- a/llvm/lib/Target/X86/X86FixupLEAs.cpp
+++ b/llvm/lib/Target/X86/X86FixupLEAs.cpp
@@ -528,12 +528,12 @@ bool FixupLEAsImpl::optLEAALU(MachineBasicBlock::iterator &I,
   NewMI1 = BuildMI(MBB, InsertPos, AluI->getDebugLoc(), TII->get(NewOpcode),
                    AluDestReg)
                .addReg(AluDestReg, RegState::Kill)
-               .addReg(BaseReg, KilledBase ? RegState::Kill : 0);
+               .addReg(BaseReg, getKillRegState(KilledBase));
   NewMI1->addRegisterDead(X86::EFLAGS, TRI);
   NewMI2 = BuildMI(MBB, InsertPos, AluI->getDebugLoc(), TII->get(NewOpcode),
                    AluDestReg)
                .addReg(AluDestReg, RegState::Kill)
-               .addReg(IndexReg, KilledIndex ? RegState::Kill : 0);
+               .addReg(IndexReg, getKillRegState(KilledIndex));
   NewMI2->addRegisterDead(X86::EFLAGS, TRI);
 
   // Clear the old Kill flags.


### PR DESCRIPTION
This Change is to prepare to make RegState into an enum class. It:
- Updates documentation to match the order in the code.
- Brings the `get<>RegState` functions together and makes them
`constexpr`.
- Adopts the `get<>RegState` where RegStates were being chosen with
ternary operators in backend code.
- Introduces `hasRegState` to make querying RegState easier once it is
an enum class.
- Adopts `hasRegState` where equivalent was done with bitwise
arithmetic.
- Introduces `RegState::NoFlags`, which will be used for the lack of
flags.
- Documents that `0x1` is a reserved flag value used to detect if
someone is passing `true` instead of flags (due to implicit bool to
unsigned conversions).
- Updates two calls to `MachineInstrBuilder::addReg` which were passing
`false` to the flags operand, to no longer pass a value.
- Documents that `getRegState` seems to have forgotten a call to
`getEarlyClobberRegState`.